### PR TITLE
Corrects the bad location of the module for the test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,14 +15,14 @@
  */
 
 buildscript {
-	repositories {
-		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-		mavenCentral()
-	}
-	dependencies {
+  repositories {
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    mavenCentral()
+  }
+  dependencies {
     classpath "org.vert-x:build-tools:$vertxBuildToolsVersion"
     classpath "org.vert-x:gradle-plugin:$vertxGradlePluginVersion"
-	}
+  }
 }
 
 apply from: 'gradle/setup.gradle'


### PR DESCRIPTION
In combination with an update to the vert.x Gradle Plugin, this build now correctly tests the local module.

run ./mk --refresh-dependencies clean test 
