### PR TITLE
added support for filtering keys/fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ To find documents send a JSON message to the module main address:
         "action": "find",
         "collection": <collection>,
         "matcher": <matcher>,
+        "keys": <keys>,
         "skip": <offset>,
         "limit": <limit>,
         "batch_size": <batch_size>
@@ -162,6 +163,7 @@ To find documents send a JSON message to the module main address:
 Where:
 * `collection` is the name of the MongoDB collection that you wish to search in in. This field is mandatory.
 * `matcher` is a JSON object that you want to match against to find matching documents. This obeys the normal MongoDB matching rues.
+* `keys` is an optional JSON object that contains the fields that should be returned for matched documents. See MongoDB manual for more information. Example: { "name": 1 } will only return objects with _id and the name field
 * `skip` is a number which determines the number of documents to skip. This is optional. By default no documents are skipped.
 * `limit` is a number which determines the maximum total number of documents to return. This is optional. By default all documents are returned.
 * `batch_size` is a number which determines how many documents to return in each reply JSON message. It's optional and the default value is `100`. Batching is discussed in more detail below.
@@ -300,12 +302,14 @@ To find a document send a JSON message to the module main address:
     {
         "action": "findone",
         "collection": <collection>,
-        "matcher": <matcher>
+        "matcher": <matcher>,
+        "keys": <keys>
     }     
     
 Where:
 * `collection` is the name of the MongoDB collection that you wish to search in in. This field is mandatory.
 * `matcher` is a JSON object that you want to match against to find a matching document. This obeys the normal MongoDB matching rues.
+* `keys` is an optional JSON object that contains the fields that should be returned for matched documents. See MongoDB manual for more information. Example: { "name": 1 } will only return objects with _id and the name field
 
 If more than one document matches, just the first one will be returned.
 

--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -204,9 +204,13 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     if (matcher == null) {
       return;
     }
+    JsonObject keys = message.body.getObject("keys");
+    
     Object sort = message.body.getField("sort");
     DBCollection coll = db.getCollection(collection);
-    DBCursor cursor = coll.find(jsonToDBObject(matcher));
+    DBCursor cursor = (keys == null) ? 
+    			coll.find(jsonToDBObject(matcher)) : 
+    			coll.find(jsonToDBObject(matcher), jsonToDBObject(keys));
     if(skip != -1) {
         cursor.skip(skip);
     }
@@ -302,12 +306,13 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
       return;
     }
     JsonObject matcher = message.body.getObject("matcher");
+    JsonObject keys = message.body.getObject("keys");
     DBCollection coll = db.getCollection(collection);
     DBObject res;
     if (matcher == null) {
-      res = coll.findOne();
+      res = keys != null ? coll.findOne(null, jsonToDBObject(keys)) : coll.findOne();
     } else {
-      res = coll.findOne(jsonToDBObject(matcher));
+      res = keys != null ? coll.findOne(jsonToDBObject(matcher), jsonToDBObject(keys)) : coll.findOne(jsonToDBObject(matcher));
     }
     JsonObject reply = new JsonObject();
     if (res != null) {

--- a/src/test/java/org/vertx/mods/tests/JavaScriptPersistorTest.java
+++ b/src/test/java/org/vertx/mods/tests/JavaScriptPersistorTest.java
@@ -71,6 +71,11 @@ public class JavaScriptPersistorTest extends TestBase {
   public void testFindWithSort() throws Exception {
     startTest(getMethodName());
   }
+  
+  @Test
+  public void testFindWithKeys() throws Exception {
+    startTest(getMethodName());
+  }
 
   @Test
   public void testFindBatched() throws Exception {

--- a/src/test/resources/test_client.js
+++ b/src/test/resources/test_client.js
@@ -247,6 +247,56 @@ function testFindWithSort() {
   });
 }
 
+function testFindWithKeys() {
+	
+    eb.send('test.persistor', {
+      collection: 'testcoll',
+      action: 'save',
+      document: {
+        name: 'tim',
+        age: Math.floor(Math.random()*11)
+      }
+    }, function(reply) {
+      tu.azzert(reply.status === 'ok');
+    });
+  
+
+  eb.send('test.persistor', {
+    collection: 'testcoll',
+    action: 'findone',
+    // matcher: {name: 'tim'},
+    keys: { name: 1},
+    sort: {age: 1}
+  }, function(reply) {
+    tu.azzert(reply.status === 'ok');
+    tu.azzert(!reply.result.age);
+  });
+
+  eb.send('test.persistor', {
+    collection: 'testcoll',
+    action: 'findone',
+    matcher: {name: 'tim'},
+    keys: { name: 1},
+    sort: {age: 1}
+  }, function(reply) {
+    tu.azzert(reply.status === 'ok');
+    tu.azzert(!reply.result.age);
+  });
+
+  eb.send('test.persistor', {
+    collection: 'testcoll',
+    action: 'find',
+    matcher: {name: 'tim'},
+    keys: { name: 1},
+    sort: {age: 1}
+  }, function(reply) {
+    tu.azzert(reply.status === 'ok');
+    tu.azzert(!reply.results[0].age);
+    tu.testComplete();
+  });
+}
+
+
 function testFindBatched() {
 
   var num = 103;


### PR DESCRIPTION
This adds an optional 'keys' field to the event message to restrict results to a list of field names.
I added a unit test (you might want to check that, not sure if I used your test framework correctly) and some documentation.
