### PR TITLE
Stop throws NPE if exception occurs in construction

### DIFF
--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -74,7 +74,9 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
   }
 
   public void stop() {
-    mongo.close();
+    if(mongo != null) {
+      mongo.close();
+    }
   }
 
   public void handle(Message<JsonObject> message) {


### PR DESCRIPTION
For instance, if an invalid configuration is provided:

```
{"port":"foobar"}
```

An exception will be thrown, prompting immediate undeployment. `mongo` will be null, so an NullPointerException will be thrown.
