### PR TITLE
Solves problem with Spring Data interoperability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Let's take a look at each field in turn:
 * `pool_size` The number of socket connections the module instance should maintain to the MongoDB server. Default is 10.
 * `fake` If true then a fake in memory Mongo DB server is used instead (using Fongo). Useful for testing!
 * `use_ssl` enable SSL based connections.  See http://docs.mongodb.org/manual/tutorial/configure-ssl/ for more details. Defaults to `false`.
+* `use_objectids` let MongoDB create unique _id for new objects. This is default. Set it to false to use more efficient simple UUID for _id.
 
 ### Replsets or sharding
 

--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -47,6 +47,7 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
   protected String username;
   protected String password;
   protected boolean autoConnectRetry;
+  protected boolean useObjectIds;
   protected int socketTimeout;
   protected boolean useSSL;
 
@@ -66,6 +67,7 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     password = getOptionalStringConfig("password", null);
     int poolSize = getOptionalIntConfig("pool_size", 10);
     autoConnectRetry = getOptionalBooleanConfig("auto_connect_retry", true);
+    useObjectIds = getOptionalBooleanConfig("use_objectids", true);
     socketTimeout = getOptionalIntConfig("socket_timeout", 60000);
     useSSL = getOptionalBooleanConfig("use_ssl", false);
 
@@ -183,12 +185,14 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     if (doc == null) {
       return;
     }
-    String genID;
-    if (doc.getField("_id") == null) {
-      genID = UUID.randomUUID().toString();
-      doc.putString("_id", genID);
-    } else {
-      genID = null;
+    String genID = null;
+    if (!useObjectIds) {
+      if (doc.getField("_id") == null) {
+        genID = UUID.randomUUID().toString();
+        doc.putString("_id", genID);
+      } else {
+        genID = null;
+      }
     }
     DBCollection coll = db.getCollection(collection);
     DBObject obj = jsonToDBObject(doc);


### PR DESCRIPTION
When using same MongoDB instance with a Java application using Spring Data to access this instance, and try to also access it with mongo-persistor, Spring Data will break after first record is added through mongo-persistor. This patch solves this, and yet preserves ability to use more efficient _id mechanism of HEAD.