### PR TITLE
Removed "fake" references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The mongo-persistor module takes the following configuration:
         "port": <port>,
         "db_name": <db_name>,
         "pool_size": <pool_size>,
-        "fake": <fake>,
         "use_ssl": <bool>,
         "read_preference": <e.g. "nearest" or "primary" etecetera>
     }
@@ -48,7 +47,6 @@ Let's take a look at each field in turn:
 * `port` Port at which the MongoDB instance is listening. Defaults to `27017`.
 * `db_name` Name of the database in the MongoDB instance to use. Defaults to `default_db`.
 * `pool_size` The number of socket connections the module instance should maintain to the MongoDB server. Default is 10.
-* `fake` If true then a fake in memory Mongo DB server is used instead (using Fongo). Useful for testing!
 * `use_ssl` enable SSL based connections.  See http://docs.mongodb.org/manual/tutorial/configure-ssl/ for more details. Defaults to `false`.
 * `read_preference` is the read preferences, see http://docs.mongodb.org/manual/core/read-preference/. Default is "primary".
 


### PR DESCRIPTION
Looks like the fake option is no longer valid, so removing the references from the documentation
