### PR TITLE
Updated with an insert endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ The module supports the following operations
 
 ### Save
 
-Saves a document in the database.
+Saves a document in the database. 
+
+**N.B. this uses the underlying mongo save option which so will insert if the `_id` is not present or update if it is**
 
 To save a document send a JSON message to the module main address:
 
@@ -127,12 +129,69 @@ If an error occurs in saving the document a reply is returned:
 
     {
         "status": "error",
-        "message": <message>
+        "message": <message>,
+        "code" : <mongo code>
     }
 
 Where
 * `message` is an error message.
+* `code` is the underlying code from mongo.
 
+### Insert
+
+Inserts a document in the database.
+
+To insert a document send a JSON message to the module main address:
+
+    {
+        "action": "insert",
+        "collection": <collection>,
+        "document": <document>
+    }
+
+Where:
+* `collection` is the name of the MongoDB collection that you wish to save the document in. This field is mandatory.
+* `document` is the JSON document that you wish to save.
+
+An example would be:
+
+    {
+        "action": "insert",
+        "collection": "users",
+        "document": {
+            "name": "tim",
+            "age": 1000,
+            "shoesize": 3.14159,
+            "username": "tim",
+            "password": "wibble"
+        }
+    }
+
+When the save complete successfully, a reply message is sent back to the sender with the following data:
+
+    {
+        "status": "ok"
+    }
+
+The reply will also contain a field `_id` if the document that was inserted didn't specify an id, this will be an automatically generated UUID, for example:
+
+    {
+        "status": "ok"
+        "_id": "ffeef2a7-5658-4905-a37c-cfb19f70471d"
+    }
+
+
+If an error occurs in saving the document a reply is returned:
+
+    {
+        "status": "error",
+        "message": <message>,
+        "code" : <mongo code>
+    }
+
+Where
+* `message` is an error message.
+* `code` is the underlying code from mongo.
 
 ### Update
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,17 +5,17 @@ modowner=io.vertx
 modname=mod-mongo-persistor
 
 # Your module version
-version=2.1.1-SNAPSHOT
+version=2.1.2-SNAPSHOT
 
 # The test timeout
 testtimeout=300
 
-mongoVersion=2.12.3
+mongoVersion=2.12.5
 
 # Set to true if you want module dependencies to be pulled in and nested inside the module itself
 pullInDeps=false
 
 gradleVersion=1.10
-vertxVersion=2.0.0-final
-toolsVersion=2.0.0-final
-junitVersion=4.10
+vertxVersion=2.1.5
+toolsVersion=2.0.3-final
+junitVersion=4.11

--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -139,6 +139,9 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
         case "save":
           doSave(message);
           break;
+        case "insert":
+          doInsert(message);
+          break;
         case "update":
           doUpdate(message);
           break;
@@ -180,9 +183,14 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
           sendError(message, "Invalid action: " + action);
       }
     } catch (MongoException e) {
-      sendError(message, e.getMessage(), e);
+      JsonObject errorJson = new JsonObject()
+              .putString("message", e.getMessage())
+              .putNumber("code", e.getCode());
+      sendStatus("error", message, errorJson );
     }
   }
+
+
 
   private void doSave(Message<JsonObject> message) {
     String collection = getMandatoryString("collection", message);
@@ -225,6 +233,46 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     }
   }
 
+  private void doInsert(Message<JsonObject> message) {
+    String collection = getMandatoryString("collection", message);
+    if (collection == null) {
+      return;
+    }
+    JsonObject doc = getMandatoryObject("document", message);
+    if (doc == null) {
+      return;
+    }
+    String genID;
+    if (doc.getField("_id") == null) {
+      genID = UUID.randomUUID().toString();
+      doc.putString("_id", genID);
+    } else {
+      genID = null;
+    }
+    DBCollection coll = db.getCollection(collection);
+    DBObject obj = jsonToDBObject(doc);
+    WriteConcern writeConcern = WriteConcern.valueOf(getOptionalStringConfig("writeConcern", ""));
+    // Backwards compatibility
+    if (writeConcern == null) {
+      writeConcern = WriteConcern.valueOf(getOptionalStringConfig("write_concern", ""));
+    }
+    if (writeConcern == null) {
+      writeConcern = db.getWriteConcern();
+    }
+
+    WriteResult res = coll.insert(obj, writeConcern);
+    if (res.getError() == null) {
+      if (genID != null) {
+        JsonObject reply = new JsonObject();
+        reply.putString("_id", genID);
+        sendOK(message, reply);
+      } else {
+        sendOK(message);
+      }
+    } else {
+      sendError(message, res.getError());
+    }
+  }
   private void doUpdate(Message<JsonObject> message) {
     String collection = getMandatoryString("collection", message);
     if (collection == null) {


### PR DESCRIPTION
I needed to use mongo with some form of optimistic locking and so had to know when an insert failed with a duplicate id.

This change exposes the insert endpoint.