### PR TITLE
Updating mongo-java-driver to latest 2.13.1 version supporting MongoDB 2.4 2.6 3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,12 +10,12 @@ version=2.1.1-SNAPSHOT
 # The test timeout
 testtimeout=300
 
-mongoVersion=2.12.3
+mongoVersion=2.13.1
 
 # Set to true if you want module dependencies to be pulled in and nested inside the module itself
 pullInDeps=false
 
 gradleVersion=1.10
-vertxVersion=2.0.0-final
-toolsVersion=2.0.0-final
+vertxVersion=2.1.5
+toolsVersion=2.1.5
 junitVersion=4.10


### PR DESCRIPTION
According to http://docs.mongodb.org/ecosystem/drivers/java/ driver mongo-java-driver version 2.13.1 has the best support across all major releases of MongoDB of the recent past (2.4 and 2.6) and the current release as well (3.0). Would be nice if mod-mongo-persistor would be able to utilize it, ideally as a release: 2.1.2 or 2.1.5 to sync it with the current vert.x release?