### PR TITLE
add updatedExisting to upsert response

### DIFF
--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -72,7 +72,7 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     useSSL = getOptionalBooleanConfig("use_ssl", false);
     useMongoTypes = getOptionalBooleanConfig("use_mongo_types", false);
 
-    logger.info("Connecting to '"+host+":"+port+"/"+dbName+" "+(username!=null?" as "+username:"anonymously"));
+    logger.debug("Connecting to '" + host + ":" + port + "/" + dbName + " " + (username != null ? " as " + username : "anonymously"));
 
     JsonArray seedsProperty = config.getArray("seeds");
 
@@ -259,7 +259,7 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     if (res.getError() == null) {
       JsonObject reply = new JsonObject();
       reply.putNumber("number", res.getN());
-      reply.putBoolean("updatedExisting",res.isUpdateOfExisting());
+      reply.putBoolean("updatedExisting", res.isUpdateOfExisting());
       sendOK(message, reply);
     } else {
       sendError(message, res.getError());

--- a/src/main/java/org/vertx/mods/MongoPersistor.java
+++ b/src/main/java/org/vertx/mods/MongoPersistor.java
@@ -72,6 +72,8 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     useSSL = getOptionalBooleanConfig("use_ssl", false);
     useMongoTypes = getOptionalBooleanConfig("use_mongo_types", false);
 
+    logger.info("Connecting to '"+host+":"+port+"/"+dbName+" "+(username!=null?" as "+username:"anonymously"));
+
     JsonArray seedsProperty = config.getArray("seeds");
 
     try {
@@ -257,6 +259,7 @@ public class MongoPersistor extends BusModBase implements Handler<Message<JsonOb
     if (res.getError() == null) {
       JsonObject reply = new JsonObject();
       reply.putNumber("number", res.getN());
+      reply.putBoolean("updatedExisting",res.isUpdateOfExisting());
       sendOK(message, reply);
     } else {
       sendError(message, res.getError());

--- a/src/test/resources/integration_tests/javascript/test_client.js
+++ b/src/test/resources/integration_tests/javascript/test_client.js
@@ -131,14 +131,14 @@ function testUpsert() {
     action: 'update',
     upsert: true,
     criteria: {
-      '_id':'12345'
+      '_id': '12345'
     },
     objNew: {
-      '$set': {'name':'roger','age':15}
+      '$set': {'name': 'roger', 'age': 15}
     }
-  }, function(reply) {
-    vassert.assertEquals("ok",reply.status);
-    vassert.assertTrue(!reply.updatedExisting);
+  }, function (reply) {
+    vassert.assertEquals("ok", reply.status);
+    vassert.assertFalse(reply.updatedExisting);
 
     // Now update it
     eb.send('test.persistor', {
@@ -146,13 +146,13 @@ function testUpsert() {
       action: 'update',
       upsert: true,
       criteria: {
-        '_id':'12345'
+        '_id': '12345'
       },
       objNew: {
-        '$set': {'age':1000}
+        '$set': {'age': 1000}
       }
-    }, function(reply) {
-      vassert.assertEquals("ok",reply.status);
+    }, function (reply) {
+      vassert.assertEquals("ok", reply.status);
       vassert.assertTrue(reply.updatedExisting);
 
       eb.send('test.persistor', {
@@ -161,12 +161,12 @@ function testUpsert() {
         document: {
           _id: '12345'
         }
-      }, function(reply) {
-        vassert.assertEquals("ok",reply.status);
+      }, function (reply) {
+        vassert.assertEquals("ok", reply.status);
         // Upsert does not remove the name
-        vassert.assertEquals("roger",reply.result.name);
+        vassert.assertEquals("roger", reply.result.name);
         // Age has changed
-        vassert.assertEquals(1000,reply.result.age,0);
+        vassert.assertEquals(1000, reply.result.age, 0);
         vassert.testComplete();
       });
     });


### PR DESCRIPTION
Using upsert there is no way to tell if the operation inserted a new document or just updated an existing one. This is just a small change to return the updatedExisting property and an associated test for upsert (as there was none)